### PR TITLE
Add missing middleware from connect

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,12 +1,14 @@
 var fs = require('fs');
 
 var express = require('express');
+var connect = require('connect');
+
 var app = express();
 
 var comments = [{author: 'Pete Hunt', text: 'Hey there!'}];
 
 app.use('/', express.static(__dirname));
-app.use(express.bodyParser());
+app.use(connect.bodyParser());
 
 app.get('/comments.json', function(req, res) {
   res.setHeader('Content-Type', 'application/json');


### PR DESCRIPTION
  Since Express 4.x no longer depends on Connect, we need to add it and then
  add the body parser middleware from it.
